### PR TITLE
update test platform string

### DIFF
--- a/schema/models/TEST_SUITE_TRACE.json
+++ b/schema/models/TEST_SUITE_TRACE.json
@@ -132,7 +132,7 @@
                       "current_day": "expect.any(Number)",
                       "user": {
                         "browserType": "chrome",
-                        "platform": "Mac OS",
+                        "platform": "mac",
                         "locale": "en",
                         "browserVersion": 80
                       },
@@ -280,7 +280,7 @@
                       "current_day": "expect.any(Number)",
                       "user": {
                         "browserType": "chrome",
-                        "platform": "Mac OS",
+                        "platform": "mac",
                         "locale": "en",
                         "browserVersion": 80
                       },
@@ -444,7 +444,7 @@
                       "current_day": "expect.any(Number)",
                       "user": {
                         "browserType": "chrome",
-                        "platform": "Mac OS",
+                        "platform": "mac",
                         "locale": "en",
                         "browserVersion": 80
                       },
@@ -650,7 +650,7 @@
                     "current_day": "expect.any(Number)",
                     "user": {
                       "browserType": "chrome",
-                      "platform": "Mac OS",
+                      "platform": "mac",
                       "locale": "en",
                       "browserVersion": 80
                     },
@@ -716,7 +716,7 @@
                     "current_day": "expect.any(Number)",
                     "user": {
                       "browserType": "chrome",
-                      "platform": "Mac OS",
+                      "platform": "mac",
                       "locale": "en",
                       "browserVersion": 80
                     },
@@ -806,7 +806,7 @@
                     "current_day": "expect.any(Number)",
                     "user": {
                       "browserType": "chrome",
-                      "platform": "Mac OS",
+                      "platform": "mac",
                       "locale": "en",
                       "browserVersion": 80
                     },
@@ -1034,7 +1034,7 @@
                       "current_day": "expect.any(Number)",
                       "user": {
                         "browserType": "chrome",
-                        "platform": "Mac OS",
+                        "platform": "mac",
                         "locale": "en",
                         "browserVersion": 80
                       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates one of the tests where platform strings are traced.  Strings were updated to match what will appear in artifacts (one of "mac", "windows" or "linux").  

Related PR: https://github.com/adobe/target-nodejs-sdk/pull/85

