### PR TITLE
fix telemetry test

### DIFF
--- a/schema/models/TEST_SUITE_TELEMETRY.json
+++ b/schema/models/TEST_SUITE_TELEMETRY.json
@@ -42,9 +42,17 @@
               {
                 "requestId": "expect.any(String)",
                 "timestamp": "expect.any(Number)",
+                "execution": "expect.any(Number)"
+              },
+              {
+                "requestId": "expect.any(String)",
+                "timestamp": "expect.any(Number)",
                 "execution": "expect.any(Number)",
+                "parsing": "expect.any(Number)",
+                "mode": "local",
                 "features": {
-                  "decisioningMethod": "on-device"
+                  "decisioningMethod": "on-device",
+                  "prefetchMboxCount": 1
                 }
               }
             ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
After updating the test schema in my last PR, the telemetry test failed.  This is because the `TEST_SUITE_TELEMETRY.JSON` file was modified directly in the `target-nodejs-sdk` repo rather than this one.  We need to be sure to make changes to the test suite in this repository and then update the other SDKs to use the updated test definitions rather than update them in the SDKs themselves.

see https://github.com/adobe/target-nodejs-sdk/blob/main/packages/target-decisioning-engine/test/schema/models/TEST_SUITE_TELEMETRY.json#L41


